### PR TITLE
Update volttron dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,8 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.8,<4.0"
-volttron = "^10.0.1a28"
+volttron = "^10.0.1a31"
+volttron-testing = "^0.3.1a8"
 
 [tool.poetry.group.dev.dependencies]
 volttron-testing = "^0.3.1a7"


### PR DESCRIPTION
Regression tests pass:

----------- coverage: platform linux, python 3.9.0-final-0 -----------
Name                                       Stmts   Miss  Cover
--------------------------------------------------------------
src/volttron/driver/base/__init__.py           0      0   100%
src/volttron/driver/base/driver.py           213     47    78%
src/volttron/driver/base/driver_locks.py      32     22    31%
src/volttron/driver/base/interfaces.py       148     88    41%
--------------------------------------------------------------
TOTAL                                        393    157    60%
